### PR TITLE
Do not redirect to github home page.

### DIFF
--- a/extension/main.js
+++ b/extension/main.js
@@ -85,11 +85,9 @@
 
 		const ghTab = {url};
 
-		if (window.GitHubNotify.settings.get('count') > 0) {
-			ghTab.url = `${url}notifications`;
-			if (window.GitHubNotify.settings.get('useParticipatingCount')) {
-				ghTab.url += '/participating';
-			}
+		ghTab.url = `${url}notifications`;
+		if (window.GitHubNotify.settings.get('useParticipatingCount')) {
+			ghTab.url += '/participating';
 		}
 
 		if (typeof tab !== 'undefined' && (tab.url === '' || tab.url === 'chrome://newtab/' || tab.url === ghTab.url)) {


### PR DESCRIPTION
Clicking on the page icon (with this PR) always takes you to the same page, even if the notification count is `0`.

Fixes #43.