### PR TITLE
Show total notifications amount (fixes issue #45)

### DIFF
--- a/extension/api.js
+++ b/extension/api.js
@@ -30,10 +30,10 @@
 		};
 	})();
 
-	const getLinkPages = (linkheader) => {
-		for (let link of linkheader.split(', ')) {
+	const getLinkPages = linkheader => {
+		for (const link of linkheader.split(', ')) {
 			if (link.endsWith('rel="last"')) {
-				return Number(link.slice(link.lastIndexOf('page=')+5, link.lastIndexOf('>')));
+				return Number(link.slice(link.lastIndexOf('page=') + 5, link.lastIndexOf('>')));
 			}
 		}
 	};
@@ -115,10 +115,10 @@
 
 			if (data && data.hasOwnProperty('length')) {
 				const pages = getLinkPages(response.getResponseHeader('Link'));
-				if (pages == 1) {
+				if (pages === 1) {
 					cb(null, data.length, interval);
 				} else {
-					cb(null, (pages-1)*data.length, interval);
+					cb(null, (pages - 1) * data.length, interval);
 					// need one more query to fetch the number
 					// of notifications on the last page
 				}

--- a/extension/api.js
+++ b/extension/api.js
@@ -69,7 +69,7 @@
 		const opts = {
 			Authorization: `token ${token}`
 		};
-		const participating = window.GitHubNotify.settings.get('useParticipatingCount') ? '?participating=true' : '';
+		const participating = window.GitHubNotify.settings.get('useParticipatingCount') ? 'participating=true' : '';
 		let url = window.GitHubNotify.settings.get('rootUrl');
 
 		if (!token) {
@@ -83,12 +83,14 @@
 			url += 'api/v3/notifications';
 		}
 
+		url += '?';
 		url += participating;
+		url += '&per_page=1';
 
 		xhr('GET', url, opts, (data, status, response) => {
 			const interval = Number(response.getResponseHeader('X-Poll-Interval'));
 			const linkheader = response.getResponseHeader('Link');
-			
+
 			const getLinkPages = linkheader => {
 				for (const link of linkheader.split(', ')) {
 					if (link.endsWith('rel="last"')) {
@@ -115,15 +117,8 @@
 				return;
 			}
 
-			if (data && data.hasOwnProperty('length')) {
-				const pages = getLinkPages(response.getResponseHeader('Link'));
-				if (pages === 1) {
-					cb(null, data.length, interval);
-				} else {
-					cb(null, (pages - 1) * data.length, interval);
-					// need one more query to fetch the number
-					// of notifications on the last page
-				}
+			if (data) {
+				cb(null, pages, interval);
 				return;
 			}
 

--- a/extension/api.js
+++ b/extension/api.js
@@ -30,14 +30,6 @@
 		};
 	})();
 
-	const getLinkPages = linkheader => {
-		for (const link of linkheader.split(', ')) {
-			if (link.endsWith('rel="last"')) {
-				return Number(link.slice(link.lastIndexOf('page=') + 5, link.lastIndexOf('>')));
-			}
-		}
-	};
-
 	window.GitHubNotify = (() => {
 		const defaults = {
 			rootUrl: 'https://api.github.com/',
@@ -95,6 +87,16 @@
 
 		xhr('GET', url, opts, (data, status, response) => {
 			const interval = Number(response.getResponseHeader('X-Poll-Interval'));
+			const linkheader = response.getResponseHeader('Link');
+			
+			const getLinkPages = linkheader => {
+				for (const link of linkheader.split(', ')) {
+					if (link.endsWith('rel="last"')) {
+						return Number(link.slice(link.lastIndexOf('page=') + 5, link.lastIndexOf('>')));
+					}
+				}
+			};
+			const pages = getLinkPages(linkheader);
 
 			if (status >= 500) {
 				cb(new Error('server error'), null, interval);

--- a/extension/api.js
+++ b/extension/api.js
@@ -72,7 +72,7 @@
 		const query = [];
 		if (window.GitHubNotify.settings.get('useParticipatingCount')) {
 			query.push('participating=true');
-		};
+		}
 		query.push('per_page=1');
 
 		let url = window.GitHubNotify.settings.get('rootUrl');
@@ -88,7 +88,7 @@
 			url += 'api/v3/notifications';
 		}
 
-		url += '?' + query.join('&');
+		url += `?${query.join('&')}`;
 
 		xhr('GET', url, opts, (data, status, response) => {
 			const interval = Number(response.getResponseHeader('X-Poll-Interval'));

--- a/extension/api.js
+++ b/extension/api.js
@@ -30,6 +30,14 @@
 		};
 	})();
 
+	const getLinkPages = (linkheader) => {
+		for (let link of linkheader.split(', ')) {
+			if (link.endsWith('rel="last"')) {
+				return Number(link.slice(link.lastIndexOf('page=')+5, link.lastIndexOf('>')));
+			}
+		}
+	};
+
 	window.GitHubNotify = (() => {
 		const defaults = {
 			rootUrl: 'https://api.github.com/',
@@ -63,14 +71,6 @@
 
 		return api;
 	})();
-
-	getLinkPages = (linkheader) => {
-		for (let link of linkheader.split(', ')) {
-			if (link.endsWith('rel="last"')) {
-				return Number(link.slice(link.lastIndexOf('page=')+5, link.lastIndexOf('>')));
-			}
-		}
-	};
 
 	window.gitHubNotifCount = cb => {
 		const token = window.GitHubNotify.settings.get('oauthToken');

--- a/extension/api.js
+++ b/extension/api.js
@@ -106,7 +106,22 @@
 			}
 
 			if (data && data.hasOwnProperty('length')) {
-				cb(null, data.length, interval);
+				function getpages(linksheader) {
+					for (var link of linksheader.split(', ')) {
+						if (link.endsWith('rel="last"')) {
+							return Number(link.slice(link.lastIndexOf('page=')+5, link.lastIndexOf('>')));
+						}
+					}
+				}
+				const pages = getpages(response.getResponseHeader('Link'));
+
+				if (pages == 1) {
+					cb(null, data.length, interval);
+				} else {
+					cb(null, (pages-1)*data.length, interval);
+					// need one more query to fetch the number
+					// of notifications on the last page
+				}
 				return;
 			}
 

--- a/extension/api.js
+++ b/extension/api.js
@@ -64,6 +64,14 @@
 		return api;
 	})();
 
+	getLinkPages = (linkheader) => {
+		for (let link of linkheader.split(', ')) {
+			if (link.endsWith('rel="last"')) {
+				return Number(link.slice(link.lastIndexOf('page=')+5, link.lastIndexOf('>')));
+			}
+		}
+	};
+
 	window.gitHubNotifCount = cb => {
 		const token = window.GitHubNotify.settings.get('oauthToken');
 		const opts = {
@@ -106,15 +114,7 @@
 			}
 
 			if (data && data.hasOwnProperty('length')) {
-				function getpages(linksheader) {
-					for (var link of linksheader.split(', ')) {
-						if (link.endsWith('rel="last"')) {
-							return Number(link.slice(link.lastIndexOf('page=')+5, link.lastIndexOf('>')));
-						}
-					}
-				}
-				const pages = getpages(response.getResponseHeader('Link'));
-
+				const pages = getLinkPages(response.getResponseHeader('Link'));
 				if (pages == 1) {
 					cb(null, data.length, interval);
 				} else {

--- a/extension/api.js
+++ b/extension/api.js
@@ -69,7 +69,12 @@
 		const opts = {
 			Authorization: `token ${token}`
 		};
-		const participating = window.GitHubNotify.settings.get('useParticipatingCount') ? 'participating=true' : '';
+		const query = [];
+		if (window.GitHubNotify.settings.get('useParticipatingCount')) {
+			query.push('participating=true');
+		};
+		query.push('per_page=1');
+
 		let url = window.GitHubNotify.settings.get('rootUrl');
 
 		if (!token) {
@@ -83,9 +88,7 @@
 			url += 'api/v3/notifications';
 		}
 
-		url += '?';
-		url += participating;
-		url += '&per_page=1';
+		url += '?' + query.join('&');
 
 		xhr('GET', url, opts, (data, status, response) => {
 			const interval = Number(response.getResponseHeader('X-Poll-Interval'));

--- a/extension/api.js
+++ b/extension/api.js
@@ -93,15 +93,10 @@
 		xhr('GET', url, opts, (data, status, response) => {
 			const interval = Number(response.getResponseHeader('X-Poll-Interval'));
 			const linkheader = response.getResponseHeader('Link');
-
-			const getLinkPages = linkheader => {
-				for (const link of linkheader.split(', ')) {
-					if (link.endsWith('rel="last"')) {
-						return Number(link.slice(link.lastIndexOf('page=') + 5, link.lastIndexOf('>')));
-					}
-				}
-			};
-			const pages = getLinkPages(linkheader);
+			const lastlink = linkheader.split(', ').find(link => {
+				return link.endsWith('rel="last"');
+			});
+			const pages = Number(lastlink.slice(lastlink.lastIndexOf('page=') + 5, lastlink.lastIndexOf('>')));
 
 			if (status >= 500) {
 				cb(new Error('server error'), null, interval);


### PR DESCRIPTION
This uses new GitHub paging for notifications API, which passes total number of pages in Link header. It also use a trick to show 1 result per page to get number of notifications as a number of pages.