### PR TITLE
Use user token to access repos, close notification on click

### DIFF
--- a/extension/main.js
+++ b/extension/main.js
@@ -56,11 +56,8 @@
 		const url = window.GitHubNotify.settings.get(notificationId);
 		if (url) {
 			window.GitHubNotify.request(url).then(res => res.json()).then(json => {
-				if (json.message === 'Not Found') {
-					openTab(window.GitHubNotify.getTabUrl());
-				} else {
-					openTab(json.html_url);
-				}
+				const tabUrl = json.message === 'Not Found' ? window.GitHubNotify.getTabUrl() : json.html_url;
+				openTab(tabUrl);
 			}).catch(() => {
 				openTab(window.GitHubNotify.getTabUrl());
 			});

--- a/extension/main.js
+++ b/extension/main.js
@@ -55,12 +55,13 @@
 	function handleNotificationClicked(notificationId) {
 		const url = window.GitHubNotify.settings.get(notificationId);
 		if (url) {
-			fetch(url).then(res => res.json()).then(json => {
+			window.GitHubNotify.request(url).then(res => res.json()).then(json => {
 				openTab(json.html_url);
 			}).catch(() => {
 				openTab(window.GitHubNotify.getTabUrl());
 			});
 		}
+		chrome.notifications.clear(notificationId);
 	}
 
 	function handleNotificationClosed(notificationId) {

--- a/extension/main.js
+++ b/extension/main.js
@@ -56,7 +56,11 @@
 		const url = window.GitHubNotify.settings.get(notificationId);
 		if (url) {
 			window.GitHubNotify.request(url).then(res => res.json()).then(json => {
-				openTab(json.html_url);
+				if (json.message === 'Not Found') {
+					openTab(window.GitHubNotify.getTabUrl());
+				} else {
+					openTab(json.html_url);
+				}
 			}).catch(() => {
 				openTab(window.GitHubNotify.getTabUrl());
 			});

--- a/extension/options.html
+++ b/extension/options.html
@@ -32,8 +32,8 @@
 			<h3>API access</h3>
 			<label for="oauth_token">Token</label>
 			<input type="text" id="oauth_token">
-			<span class="description"><a id="gh_link" href="https://github.com/settings/tokens/new?scopes=notifications&description=Notifier for GitHub Chrome extension" target="gh_target">Create a token</a> with the <strong>notifications</strong> permission and specify it.</span><br />
-			<span class="description">If you have private repositories, you'll need to <a id="gh_link" href="https://github.com/settings/tokens/new?scopes=notifications,repo&description=Notifier for GitHub Chrome extension" target="gh_target">create a token</a> with the <strong>notifications</strong> and <strong>repo</strong> permissions and specify it.</span>
+			<span class="description">For public repositories, <a id="gh_link" href="https://github.com/settings/tokens/new?scopes=notifications&description=Notifier for GitHub Chrome extension" target="gh_target">create a token</a> with the <strong>notifications</strong> permission and specify it.</span><br />
+			<span class="description">If you want notifications for private repositories, you'll need to <a id="gh_link" href="https://github.com/settings/tokens/new?scopes=notifications,repo&description=Notifier for GitHub Chrome extension" target="gh_target">create a token</a> with the <strong>notifications</strong> and <strong>repo</strong> permissions.</span>
 		</section>
 		<section>
 			<h3>Participating Count</h3>

--- a/extension/options.html
+++ b/extension/options.html
@@ -32,7 +32,8 @@
 			<h3>API access</h3>
 			<label for="oauth_token">Token</label>
 			<input type="text" id="oauth_token">
-			<span class="description"><a id="gh_link" href="https://github.com/settings/tokens/new?scopes=notifications&description=Notifier for GitHub Chrome extension" target="gh_target">Create a token</a> with the <strong>notifications</strong> permission and specify it</span>
+			<span class="description"><a id="gh_link" href="https://github.com/settings/tokens/new?scopes=notifications&description=Notifier for GitHub Chrome extension" target="gh_target">Create a token</a> with the <strong>notifications</strong> permission and specify it.</span><br />
+			<span class="description">If you have private repositories, you'll need to <a id="gh_link" href="https://github.com/settings/tokens/new?scopes=notifications,repo&description=Notifier for GitHub Chrome extension" target="gh_target">create a token</a> with the <strong>notifications</strong> and <strong>repo</strong> permissions and specify it.</span>
 		</section>
 		<section>
 			<h3>Participating Count</h3>

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ If you want to receive desktop notifications for public repositories, you can en
 
 #### Repos permission
 
-If you want to receive (useful) desktop notifications for any private repositories you have, you will be asked for the repo permission as well. This is due to GitHub's current permission scheme, as the only way we can read anything about your private repos is if we have full control over them. If you're concerned with your security in this manner please feel free to not give this permission, just be aware that if you do not enable this permission, clicking on the notification will take you to the new tab page since we can't get any information about the repo you got the notification for.
+If you want to receive (useful) desktop notifications for any private repositories you have, you will be asked for the repo permission as well. This is due to GitHub's current permission scheme, as the only way we can read anything about your private repos is if we have full control over them. If you're concerned with your security in this manner please feel free to not give this permission, just be aware that if you do not enable this permission, clicking on the notification will take you to the notifications home page since we can't get any information about the repo you got the notification for.
 
 
 ## Desktop notifications

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,11 @@ The first time you click on the extension icon, it will ask you for access to br
 
 #### Notifications permission
 
-If you want to receive desktop notifications, you can enable them on extension options page. You will then be asked for the notifications permission.
+If you want to receive desktop notifications for public repositories, you can enable them on extension options page. You will then be asked for the notifications permission.
+
+#### Repos permission
+
+If you want to receive desktop notifications for any private repositories you have, you will be asked for the repo permission as well. This is due to GitHub's current permission scheme, as the only way we can read anything about your private repos is if we have full control over them. If you're concerned with your security in this manner please feel free to not give this permission, just be aware that there will be some odd behaviour when it comes to private repositories.
 
 
 ## Desktop notifications

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ If you want to receive desktop notifications for public repositories, you can en
 
 #### Repos permission
 
-If you want to receive desktop notifications for any private repositories you have, you will be asked for the repo permission as well. This is due to GitHub's current permission scheme, as the only way we can read anything about your private repos is if we have full control over them. If you're concerned with your security in this manner please feel free to not give this permission, just be aware that there will be some odd behaviour when it comes to private repositories.
+If you want to receive (useful) desktop notifications for any private repositories you have, you will be asked for the repo permission as well. This is due to GitHub's current permission scheme, as the only way we can read anything about your private repos is if we have full control over them. If you're concerned with your security in this manner please feel free to not give this permission, just be aware that if you do not enable this permission, clicking on the notification will take you to the new tab page since we can't get any information about the repo you got the notification for.
 
 
 ## Desktop notifications

--- a/test/index.js
+++ b/test/index.js
@@ -55,6 +55,7 @@ describe('basic functionality', () => {
 	it('should register alarm callback', () => {
 		require('../extension/api');
 		require('../extension/main');
+
 		assert(chrome.alarms.create.called);
 	});
 


### PR DESCRIPTION
Fixes #82 by using the user's provided token to access the html_url for a repository, which was previously not being found without the user's access level. Unfortunately this also means that the token provided must give full repo access. I've added some text to the options window that has a link to the kind of token they need to create.

Here's what the options page looks like now:
![image](https://cloud.githubusercontent.com/assets/8973794/15339561/46b58bdc-1c42-11e6-9f25-91ec8a09b250.png)
