### PR TITLE
Fix query params in checkDesktopNotifications

### DIFF
--- a/extension/main.js
+++ b/extension/main.js
@@ -45,7 +45,7 @@
 
 	function checkDesktopNotifications(lastModifed) {
 		const query = window.GitHubNotify.buildQuery({perPage: 100});
-		const url = `${window.GitHubNotify.getApiUrl()}?${query}`;
+		const url = `${window.GitHubNotify.getApiUrl()}?${query.join('&')}`;
 
 		window.GitHubNotify.request(url).then(res => res.json()).then(notifications => {
 			showDesktopNotifications(notifications, lastModifed);


### PR DESCRIPTION
* Fixes https://github.com/sindresorhus/notifier-for-github-chrome/issues/78

Looking at the [implementation](https://github.com/sindresorhus/notifier-for-github-chrome/blob/2.5.0/extension/api.js#L96-L103) of `buildQuery` it seems that the desired behaviour was to show only participating notifications if that option was enabled

This was not happening because `{ perPage:10,  participating: true }.toString() => perPage=10,participating=true`

Similar case for showing the notification count: https://github.com/sindresorhus/notifier-for-github-chrome/blob/2.5.0/extension/api.js#L107