### PR TITLE
Use type="password" for the OAuth token field

### DIFF
--- a/extension/options.html
+++ b/extension/options.html
@@ -10,7 +10,7 @@
 			section h3 {
 				-webkit-margin-start: -18px;
 			}
-			input[type='text'] {
+			input[type='text'], input[type='password'] {
 				width: 350px;
 			}
 			span.description {
@@ -31,7 +31,7 @@
 		<section>
 			<h3>API access</h3>
 			<label for="oauth_token">Token</label>
-			<input type="text" id="oauth_token">
+			<input type="password" id="oauth_token">
 			<span class="description">For public repositories, <a id="gh_link" href="https://github.com/settings/tokens/new?scopes=notifications&description=Notifier for GitHub Chrome extension" target="gh_target">create a token</a> with the <strong>notifications</strong> permission and specify it.</span><br />
 			<span class="description">If you want notifications for private repositories, you'll need to <a id="gh_link" href="https://github.com/settings/tokens/new?scopes=notifications,repo&description=Notifier for GitHub Chrome extension" target="gh_target">create a token</a> with the <strong>notifications</strong> and <strong>repo</strong> permissions.</span>
 		</section>


### PR DESCRIPTION
When using this extension, I've found it annoying that the OAuth token gets displayed whenever I open the options menu. It seems unnecessary to display the OAuth token that's currently being used, and it's also a mild security risk (the token is visible to anyone looking over my shoulder).

This PR changes the OAuth token field to use `<input type="password">`, to prevent the token from being displayed in plaintext.