### PR TITLE
Make the notification tab "active" instead of "highlighted" (fixes #102)

### DIFF
--- a/extension/main.js
+++ b/extension/main.js
@@ -160,8 +160,8 @@
 				const currentWindow = true;
 				chrome.tabs.query({currentWindow, url}, tabs => {
 					if (tabs.length > 0) {
-						const highlighted = true;
-						chrome.tabs.update(tabs[0].id, {highlighted, url});
+						const active = true;
+						chrome.tabs.update(tabs[0].id, {active, url});
 					} else if (tab && tab.url === 'chrome://newtab/') {
 						chrome.tabs.update(null, {url});
 					} else {


### PR DESCRIPTION
A tab in Chrome is *active* when it's the currently-selected tab in a window. Only one tab per window can be active at a time.

A *highlighted* tab is slightly different; multiple tabs can be highlighted at a time. User actions such as Cmd-W apply to all highlighted tabs. (As a demo: View one tab, then shift-click on another tab. All the tabs between the two will be given a lighter color, indicating that they are highlighted. Pressing Cmd-W will close all of the highlighted tabs.)

See [here](https://groups.google.com/a/chromium.org/forum/#!topic/chromium-extensions/hEDShE5Dwe0) for more information on the distinction between these two tab states.

Notifier for GitHub looks for a tab that is already opened to the GitHub notifications page. If it finds one, it *highlights* it. This leaves the previous tab highlighted, so pressing Cmd-W will also close the tab that the user was previously using (see https://github.com/sindresorhus/notifier-for-github-chrome/issues/102).

This PR fixes the issue by marking the notifications tab as *active* instead of *highlighted*. This has the effect of un-highlighting other tabs to prevent them from being accidentally closed.