### PR TITLE
Fix offline bug when connection restored & immediate update

### DIFF
--- a/extension/main.js
+++ b/extension/main.js
@@ -81,7 +81,7 @@ function handleInstalled(details) {
 
 function handleConnectionStatus(event) {
 	if (event.type === 'online') {
-		scheduleAlaram();
+		update();
 	} else if (event.type === 'offline') {
 		handleOfflineStatus();
 	}


### PR DESCRIPTION
I found that very often when the internet connection was restored, the extension would stay in offline mode and not successfully wake back up. I believe this will fix that as well as have the added benefit of immediately getting the current notification count as time may have passed since we went offline.

I'm not fully certain why `scheduleAlaram()` doesn't effectively wake the extension. It should wake the extension 1 minute after the connection is restored via the alarm, but doesn't seem to. 

Nevertheless, it would be nice to update immediately when restored. This PR will do that via calling `update()` immediately after we come back online.