### PR TITLE
Make compatible with Firefox 55

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -29,5 +29,11 @@
 	"options_ui": {
 		"page": "options.html",
 		"chrome_style": true
+	},
+	"applications": {
+		"gecko": {
+			"id": "jid1-DMjSwVBPnk7a1Q@jetpack",
+			"strict_min_version": "55.0"
+		}
 	}
 }

--- a/extension/options.html
+++ b/extension/options.html
@@ -31,8 +31,8 @@
 			<h3>API access</h3>
 			<label for="oauth_token">Token</label>
 			<input type="password" id="oauth_token">
-			<span class="description">For public repositories, <a id="gh_link" href="https://github.com/settings/tokens/new?scopes=notifications&description=Notifier for GitHub Chrome extension" target="gh_target">create a token</a> with the <strong>notifications</strong> permission and specify it.</span><br />
-			<span class="description">If you want notifications for private repositories, you'll need to <a id="gh_link" href="https://github.com/settings/tokens/new?scopes=notifications,repo&description=Notifier for GitHub Chrome extension" target="gh_target">create a token</a> with the <strong>notifications</strong> and <strong>repo</strong> permissions.</span>
+			<span class="description">For public repositories, <a id="gh_link" href="https://github.com/settings/tokens/new?scopes=notifications&description=Notifier for GitHub extension" target="gh_target">create a token</a> with the <strong>notifications</strong> permission and specify it.</span><br />
+			<span class="description">If you want notifications for private repositories, you'll need to <a id="gh_link" href="https://github.com/settings/tokens/new?scopes=notifications,repo&description=Notifier for GitHub extension" target="gh_target">create a token</a> with the <strong>notifications</strong> and <strong>repo</strong> permissions.</span>
 		</section>
 		<section>
 			<h3>Participating Count</h3>


### PR DESCRIPTION
This extension uses APIs which are only available in Firefox 55+, and as such the [`strict_min_version`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/applications) has been set to `55.0`. Chrome does the exact same thing with [`minimum_chrome_version`](https://developer.chrome.com/extensions/manifest/minimum_chrome_version).

## What my comment on [#118](https://github.com/sindresorhus/notifier-for-github-chrome/issues/118#issuecomment-303750401) says:
> ### I recommend looking at the following resources:
> - https://developer.mozilla.org/Add-ons/WebExtensions/Porting_a_Google_Chrome_extension
> - https://developer.mozilla.org/Add-ons/WebExtensions/Porting_a_legacy_Firefox_add-on
> - https://developer.mozilla.org/Add-ons/WebExtensions/WebExtensions_and_the_Add-on_ID
> - https://developer.mozilla.org/Add-ons/WebExtensions/Publishing_your_WebExtension
> - https://developer.mozilla.org/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs
> (For determining the minimum supported Firefox version)
> 
> ### Add-on ID and the minimum supported Firefox version
> Since this addon has been published to AMO in the past, it is recommended that you set the Add-on ID to what it was in the legacy version.
> 
> This is achieved by adding the [`applications`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/applications) key to `manifest.json`:
> ```json5
> "applications": {
> 	"gecko": {
> 		// This is the Add-on ID as it was
> 		// in the SDK version of the Add-on:
> 		"id": "jid1-DMjSwVBPnk7a1Q@jetpack",
> 
> 		// This is the minimum Firefox version that supports
> 		// all the APIs needed by this WebExtension.
> 		// I have looked through the source code,
> 		// and it should be correct. (The `permissions` API
> 		// will be implemented in Firefox 55 (Bug 1197420))
> 		"strict_min_version": "55.0"
> 
> 		// If you don’t care about the `permissions` API,
> 		// then you need to set `strict_min_version` to `52.0`
> 		// and create a dummy version of `PermissionsService`
> 		// for the Firefox version that auto-resolves
> 		// all Promises to `undefined` until Firefox 55.0
> 		// gets released.
> 	}
> }
> ```
> 
> ### Blocked by:
> - https://bugzilla.mozilla.org/show_bug.cgi?id=1197420

---

Moved from #128